### PR TITLE
Optimizations and fixes

### DIFF
--- a/dependencies/union/gothic-userapi/zCParser.inl
+++ b/dependencies/union/gothic-userapi/zCParser.inl
@@ -1,3 +1,3 @@
-void CallFunc(int function, std::vector<Parameter>);
+void CallFunc(int function, const std::vector<Parameter>&);
 void DeclareAI_CallFunction_variadic();
 void DeclareFuncCall_U(zSTRING &name, int typematch);

--- a/src/Plugin.hpp
+++ b/src/Plugin.hpp
@@ -1,6 +1,4 @@
 // This file is included separately for each engine version
-#include <iostream>
-#include <string>
 namespace GOTHIC_NAMESPACE
 {
     // There is a problem: 

--- a/src/Plugin.hpp
+++ b/src/Plugin.hpp
@@ -1,4 +1,5 @@
 // This file is included separately for each engine version
+#include <utility>
 namespace GOTHIC_NAMESPACE
 {
     // There is a problem: 
@@ -58,7 +59,7 @@ namespace GOTHIC_NAMESPACE
             }
 
             self->GetEM(false)->OnMessage(
-                new oCMsgAI(oCMsgAI::EV_CALLFUNC, function, args, self),
+                new oCMsgAI(oCMsgAI::EV_CALLFUNC, function, std::move(args), self),
                 self
             );
         }

--- a/src/oCMsgAI.hpp
+++ b/src/oCMsgAI.hpp
@@ -102,7 +102,7 @@ namespace GOTHIC_NAMESPACE {
            
 
             int del{};
-            switch (csg->GetSubType()) {
+            switch (aiMsg->GetSubType()) {
             case oCMsgAI::EV_CALLFUNC: del = EV_CallFunction(aiMsg);      break;
             }
             aiMsg->Release();

--- a/src/oCMsgAI.hpp
+++ b/src/oCMsgAI.hpp
@@ -93,27 +93,23 @@ namespace GOTHIC_NAMESPACE {
 
     void oCNpc::OnMessage_U(zCEventMessage* eventMessage, zCVob* sourceVob)
     {
-        if (!IsMessageAIEnabled()) {
-            eventMessage->Delete();
-            return;
-        }
+        if (auto aiMsg = zDYNAMIC_CAST<oCMsgAI>(eventMessage))
+        {
+            //make sure message won't be deleted on call to the engine
+            aiMsg->AddRef();
+            // Call the original function
+            (this->*Hook_OnMessage)(eventMessage, sourceVob);
+           
 
-        if (!GetVisual() || !GetAnictrl()) AvoidShrink(1000);
-
-        if (!GetAnictrl()) InitHumanAI();
-        anictrl = GetAnictrl();
-
-        eventMessage->AddRef();
-
-        zBOOL del = TRUE;
-
-        if (zDYNAMIC_CAST<oCMsgAI>(eventMessage)) {
-
-            oCMsgAI* csg = (oCMsgAI*)eventMessage;
+            int del{};
             switch (csg->GetSubType()) {
-            case oCMsgAI::EV_CALLFUNC: del = EV_CallFunction(csg);      break;
+            case oCMsgAI::EV_CALLFUNC: del = EV_CallFunction(aiMsg);      break;
             }
-            if (del) csg->Delete();
+            aiMsg->Release();
+
+            if (del) aiMsg->Delete();
+
+            return;
         }
 
         // Call the original function

--- a/src/oCMsgAI.hpp
+++ b/src/oCMsgAI.hpp
@@ -105,10 +105,10 @@ namespace GOTHIC_NAMESPACE {
             switch (aiMsg->GetSubType()) {
             case oCMsgAI::EV_CALLFUNC: del = EV_CallFunction(aiMsg);      break;
             }
-            aiMsg->Release();
 
             if (del) aiMsg->Delete();
 
+            aiMsg->Release();
             return;
         }
 

--- a/src/oCMsgAI.hpp
+++ b/src/oCMsgAI.hpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <utility>
 
 namespace GOTHIC_NAMESPACE {
     using Parameter = std::variant<Int, Float, String, Instance>;
@@ -21,7 +22,7 @@ namespace GOTHIC_NAMESPACE {
         oCMsgAI(AI_type subType, int fn_index, std::vector<Parameter> params, oCNpc* self) {
             this->subType = subType;
             this->function_index = fn_index;
-            this->params = params;
+            this->params = std::move(params);
         };
         virtual ~oCMsgAI() {};
 

--- a/src/zCParser.hpp
+++ b/src/zCParser.hpp
@@ -38,7 +38,6 @@ namespace GOTHIC_NAMESPACE
                         zCPar_Symbol* par = this->GetSymbol(function + i);
                         zCPar_Symbol* inst_sym = this->GetSymbol(arg.value);
                         if (inst_sym && par) {
-                            par->SetValue(arg.value, 0);
                             this->datastack.Push(arg.value);
                             // This does not have to be there for some reason
                             //if (!sym->HasFlag(zPAR_FLAG_EXTERNAL))

--- a/src/zCParser.hpp
+++ b/src/zCParser.hpp
@@ -1,3 +1,4 @@
+#include <bit>
 namespace GOTHIC_NAMESPACE
 {
     // This should rewriten to accept a Zengin container instead of std::vector
@@ -15,7 +16,7 @@ namespace GOTHIC_NAMESPACE
                         this->datastack.Push(arg.value);
                         this->datastack.Push(zPAR_TOK_PUSHINT);
                     } else if constexpr (std::is_same_v<T, Float>) {
-                        this->datastack.Push(*((int*)&arg.value));
+                        this->datastack.Push(std::bit_cast<int>(arg.value));
                         this->datastack.Push(zPAR_TOK_PUSHINT);
                     }
                     else if constexpr (std::is_same_v<T, String>) {

--- a/src/zCParser.hpp
+++ b/src/zCParser.hpp
@@ -12,25 +12,13 @@ namespace GOTHIC_NAMESPACE
                 {
                     using T = std::decay_t<decltype(arg)>;
                     if constexpr (std::is_same_v<T, Int>) {
-                        zCPar_Symbol* par = this->GetSymbol(function + i);
-                        if (par)
-                            par->SetValue(arg.value, 0);
-    
                         this->datastack.Push(arg.value);
                         this->datastack.Push(zPAR_TOK_PUSHINT);
                     } else if constexpr (std::is_same_v<T, Float>) {
-                        zCPar_Symbol* par = this->GetSymbol(function + i);
-                        if (par) 
-                            par->SetValue(arg.value, 0);
-    
                         this->datastack.Push(*((int*)&arg.value));
                         this->datastack.Push(zPAR_TOK_PUSHINT);
                     }
                     else if constexpr (std::is_same_v<T, String>) {
-                        zCPar_Symbol* par = this->GetSymbol(function + i);
-                        if (par) 
-                            zSTRING* x = (zSTRING*)arg.value;
-    
                         this->datastack.Push(arg.value);
                         this->datastack.Push(zPAR_TOK_PUSHVAR);
                     }

--- a/src/zCParser.hpp
+++ b/src/zCParser.hpp
@@ -1,7 +1,7 @@
 namespace GOTHIC_NAMESPACE
 {
     // This should rewriten to accept a Zengin container instead of std::vector
-    void zCParser::CallFunc(int function, std::vector<Parameter> params) {
+    void zCParser::CallFunc(int function, const std::vector<Parameter>& params) {
         int pos;
         zCPar_Symbol* sym = parser->GetSymbol(function);
         datastack.Clear();


### PR DESCRIPTION
Added move constructor calls instead of copying every time the Parameter vector, changed CallFunc to take a const ref to the vector.
Removed a few unnecessary calls and headers.
Fixed a bug with calling SetValue on an instance.
A float value now uses bitcast to cast it to float so as not to use UB. If you don't want to use C++20, call memcpy instead.
I also moved the message function call after the original method call so that you don't have to call methods like InitHumanAI and provide better compatibility with other plugins if IsMessageAIEnabled = false.
Please give your opinion on this PR.